### PR TITLE
feat: update role service to start Kafka consumer

### DIFF
--- a/role-service/infrastructure/kafka_consumer.go
+++ b/role-service/infrastructure/kafka_consumer.go
@@ -1,18 +1,17 @@
 package infrastructure
 
 import (
-	"context"
 	"log"
 	"role-service/domain"
 )
 
-func StartGuildCreatedConsumer(ctx context.Context, client *KafkaClient, service domain.RoleService) {
+func StartGuildCreatedConsumer(client *KafkaClient, service domain.RoleService) {
 	go func() {
 		log.Println("Starting Guild Created Event consumer...")
 
 		err := ConsumeMessages[domain.GuildCreatedEvent](
 			client,
-			"create-guild",   // Topic à écouter
+			"create-guild", // Topic à écouter
 			"role-service", // ID du groupe de consommateurs
 			func(event domain.GuildCreatedEvent) error {
 				log.Printf("Received guild created event: ID=%s, Name=%s, OwnerID=%s",

--- a/role-service/main.go
+++ b/role-service/main.go
@@ -26,7 +26,9 @@ func main() {
 	roleRepository := repositories.NewPostgresRoleRepository(db)
 	roleService := application.NewRoleService(roleRepository, kafka)
 
+	infrastructure.StartGuildCreatedConsumer(kafka, roleService)
+
 	httpServer := application.NewHTTPServer(roleService)
 
-	log.Fatal(httpServer.Start(":3333"))
+	log.Fatal(httpServer.Start(":3335"))
 }


### PR DESCRIPTION
- Added the StartGuildCreatedConsumer function to initialize the Kafka consumer for guild creation events.
- Updated the HTTP server to listen on port 3335 instead of 3333.